### PR TITLE
turn off the progress stream to prevent it from getting merged into stderr

### DIFF
--- a/lib/kitchen/driver/winrm_base.rb
+++ b/lib/kitchen/driver/winrm_base.rb
@@ -104,7 +104,8 @@ module Kitchen
       end
 
       def env_cmd(cmd)
-        env = ""
+        #The progress strean may get sent to stderr, so turn it off
+        env = "$ProgressPreference=\"SilentlyContinue\";"
         env << " $env:http_proxy=\"#{config[:http_proxy]}\";"   if config[:http_proxy]
         env << " $env:https_proxy=\"#{config[:https_proxy]}\";" if config[:https_proxy]
 


### PR DESCRIPTION
I have been noticing that when converging the first time and also on kitchen setup, kitchen fails with false errors. These come from the powershell progress stream sending progress activity to stderr with harmless messages. Here is an example:

```
>>>>>> Verify failed on instance <default-windows-2012R2>.
>>>>>> Please see .kitchen/logs/default-windows-2012R2.log for more details
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: WinRM exited (0) using shell [powershell] for command: [$env:BUSSER_ROOT="/tmp/busser"; $env:GEM_HOME="/tmp/busser/gems"; $env:GEM_PATH="/tmp/busser/gems"; $env:PATH="$env:PATH;$env:GEM_PATH/bin"; $env:GEM_CACHE="/tmp/busser/gems/cache"; busser suite cleanup; echo "Uploading $(busser suite path)/serverspec/simple_spec.rb (mode=0644)"; echo "cmVxdWlyZSAnc2VydmVyc3BlYycKCmluY2x1ZGUgU2VydmVyc3BlYzo6SGVscGVyOjpFeGVjCmluY2x1ZGUgU3BlY0luZnJhOjpIZWxwZXI6OkRldGVjdE9TCgpkZXNjcmliZSBmaWxlKCdDOlxccHJvZ3JhbWRhdGFcXGNob2NvbGF0ZXlcXGJpblxcY29uc29sZS5leGUnKSBkbwogIGl0IHsgc2hvdWxkIGJlX2ZpbGUgfQplbmQ=" | busser deserialize --destination=$(busser suite path)/serverspec/simple_spec.rb --md5sum=8d037f1cc5c376eeb5ae8925766091f0 --perms=0644; ]
ERROR:
>>>>>> ----------------------
```

from:

```
{:stderr=>"<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\"><Obj S=\"progress\" RefId=\"0\"><TN RefId=\"0\"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N=\"SourceId\">1</I64><PR N=\"Record\"><AV>Preparing m"}
{:stderr=>"odules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S=\"progress\" RefId=\"1\"><TNRef RefId=\"0\" /><MS><I64 N=\"SourceId\">2</I64><PR N=\"Record\"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>"}
```
