### PR TITLE
Fix to work with http chef_omnibus_url

### DIFF
--- a/lib/kitchen/provisioner/chef_base.rb
+++ b/lib/kitchen/provisioner/chef_base.rb
@@ -191,7 +191,7 @@ module Kitchen
           install_flags = %w[latest true].include?(version) ? "" : "v=#{version}"
 
           # If we have the default URL for UNIX then we change it for the Windows version.
-          if config[:chef_omnibus_url].eql?("https://www.getchef.com/chef/install.sh")
+          if config[:chef_omnibus_url] =~ %r{http[s]*://www.getchef.com/chef/install.sh}
             chef_url = "http://www.getchef.com/chef/install.msi?#{install_flags}"
           else
             # We use the one that comes from kitchen.yml


### PR DESCRIPTION
You already merged this earlier, but I think you did a force push or something earlier which wiped it out.

Often people will reference getchef.com with http rather then https
for either using proxy caching software or due to The Enterprise
SSL proxy.  This allows the chef_omnibus_url to properly be updated
from .sh to .msi when referenced with http and not https.
