### PR TITLE
Busser and transport enhancements

### DIFF
--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -414,6 +414,7 @@ module Kitchen
         ].join(" ")
       when "powershell"
         [
+          %{Set-ExecutionPolicy RemoteSigned},
           %{$env:BUSSER_ROOT="#{config[:root_path]}";},
           %{$env:PATH="$env:PATH;/opscode/chef/embedded/bin";},
           %{try { $env:BUSSER_SUITE_PATH=@(#{@config[:busser_bin]} suite path) }},

--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -114,7 +114,7 @@ module Kitchen
       Util.wrap_command(cmd, shell)
     end
 
-    # Prepare function to prepare busser test files for a transfer
+    # Prepare busser test files to be transferred to the target system
     #
     # @return [Hash] a hash list of local transfer files with its remote target directory
     def sync_files

--- a/lib/kitchen/busser.rb
+++ b/lib/kitchen/busser.rb
@@ -165,7 +165,10 @@ module Kitchen
       when "powershell"
         cmd = <<-CMD.gsub(/^ {10}/, "")
           #{busser_setup_env}
+          echo 'Cleaning up busser...'
+          gem uninstall #{plugins.join(" ")}
 
+          echo 'Setting up busser...'
           if ((gem list busser -i) -eq \"false\") {
             gem install #{gem_install_args}
           }
@@ -414,7 +417,6 @@ module Kitchen
         ].join(" ")
       when "powershell"
         [
-          %{Set-ExecutionPolicy RemoteSigned},
           %{$env:BUSSER_ROOT="#{config[:root_path]}";},
           %{$env:PATH="$env:PATH;/opscode/chef/embedded/bin";},
           %{try { $env:BUSSER_SUITE_PATH=@(#{@config[:busser_bin]} suite path) }},

--- a/lib/kitchen/data_munger.rb
+++ b/lib/kitchen/data_munger.rb
@@ -96,6 +96,7 @@ module Kitchen
         set_kitchen_config_at!(tdata, :kitchen_root)
         set_kitchen_config_at!(tdata, :test_base_path)
         set_kitchen_config_at!(tdata, :log_level)
+        tdata[:ssh_key] = data[:driver][:ssh_key]
         combine_arrays!(tdata, :run_list, :platform, :suite)
       end
     end

--- a/lib/kitchen/driver/base.rb
+++ b/lib/kitchen/driver/base.rb
@@ -20,6 +20,7 @@ require "thor/util"
 
 require "kitchen/lazy_hash"
 
+
 module Kitchen
 
   module Driver
@@ -86,14 +87,23 @@ module Kitchen
         end
       end
 
-      # Verifies a converged instance.
+      # Uploads latest test files and verifies a converged instance.
       #
       # @param state [Hash] mutable instance and driver state
       # @raise [ActionFailed] if the action could not be completed
       def verify(state)
         transport.connection(state) do |conn|
+
+          conn.execute(busser.cleanup_cmd)
+
+          busser.sync_files.each do |file|
+            conn.upload!(file[:local], file[:remote])
+          end
+
           conn.execute(busser.sync_cmd)
           conn.execute(busser.run_cmd)
+
+          conn.execute(busser.cleanup_cmd)
         end
       end
 

--- a/lib/kitchen/transport/ssh.rb
+++ b/lib/kitchen/transport/ssh.rb
@@ -46,6 +46,8 @@ module Kitchen
 
       # (see Base#upload!)
       def upload!(local, remote, options = {}, &progress)
+        return if local.nil? || local.empty?
+        
         options = { :recursive => true }.merge(options)
 
         if progress.nil?
@@ -56,6 +58,8 @@ module Kitchen
           }
         end
 
+
+        local = Array.new(1) { local } if local.is_a? String
         local.each do |path|
           session.scp.upload!(path, remote, options, &progress)
         end

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -28,10 +28,9 @@ if defined?(WinRM).nil?
 end
 
 require "logger"
-require 'pry'
-
 require "kitchen/errors"
 require "kitchen/login_command"
+
 module Kitchen
 
   module Transport
@@ -328,7 +327,6 @@ module Kitchen
           end
           logger.debug("Finished '#{remote}' Thread: #{Thread.current}")
         end
-        #binding.pry
       end
 
       # Checks to see if the target file on the guest is missing or out of date.
@@ -361,9 +359,7 @@ if (Test-Path $dest_file_path) {
 return 1
         EOH
         result = powershell(command)
-        #should = (powershell(command)[:exitcode] == 1)
         should = (result[:data][0][:stdout] == "1")
-        #binding.pry
         should
       end
 
@@ -418,7 +414,6 @@ return 1
           [System.IO.File]::WriteAllBytes($dest_file_path, $bytes)
         EOH
         raise_upload_error_if_failed(output, local, remote)
-        ##binding.pry
       end
 
       # Creates a guest file path equivalent from a host file path

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -78,6 +78,8 @@ module Kitchen
 
       # (see Base#upload!)
       def upload!(local, remote)
+        return if local.nil? || local.empty?
+
         logger.info("Concurrent threads set to :max_threads => #{config[:max_threads]}")
         logger.debug("Upload: #{local} -> #{remote}")
         local = Array.new(1) { local } if local.is_a? String

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -28,6 +28,7 @@ if defined?(WinRM).nil?
 end
 
 require "logger"
+require 'pry'
 
 require "kitchen/errors"
 require "kitchen/login_command"
@@ -327,6 +328,7 @@ module Kitchen
           end
           logger.debug("Finished '#{remote}' Thread: #{Thread.current}")
         end
+        #binding.pry
       end
 
       # Checks to see if the target file on the guest is missing or out of date.
@@ -351,12 +353,18 @@ if (Test-Path $dest_file_path) {
     $file.Dispose()
   }
   if ($guest_md5 -eq '#{local_md5}') {
-    exit 0
+    [Environment]::ExitCode = 0
+    return 0
   }
 }
-exit 1
+[Environment]::ExitCode = 1
+return 1
         EOH
-        powershell(command)[:exitcode] == 1
+        result = powershell(command)
+        #should = (powershell(command)[:exitcode] == 1)
+        should = (result[:data][0][:stdout] == "1")
+        #binding.pry
+        should
       end
 
       # Uploads the given file to a new temp file on the guest
@@ -410,6 +418,7 @@ exit 1
           [System.IO.File]::WriteAllBytes($dest_file_path, $bytes)
         EOH
         raise_upload_error_if_failed(output, local, remote)
+        ##binding.pry
       end
 
       # Creates a guest file path equivalent from a host file path


### PR DESCRIPTION
Hi Salim,

We started utilizing test-kitchen and kitchen-ec2 quite heavily, as it makes our job so much easier to test and verify our Windows cookbooks properly in Amazon. So here's my new batch of contribution for the Windows / WinRm support to your review - this time for test-kitchen. :)

The main change is that - I've realized during `kitchen verify` executions, that `busser_sync` method is responsible for pushing the test files, which breaks with WinRM, if the test files are getting larger - due to the command length limitations of the WinRM service. So my idea was to move them with the standard transport layer (both for ssh and winrm) and let `busser_sync` only do the preparation on the already transported files from a temp folder.

The changes namely:
- Added a file-transfer phase for busser to push files via the regular transport layer (both SSH and WinRM) with the help of temporary transport folders
- Improved reliability for MD5 hash checks via WinRM by passing ExitCodes through outputs too for PS backward compatibility, as winrm can't always capture the code after `Exit` command
  - Improved busser cleanup to make `kitchen setup` repeatable by removing and reinstalling plugins
  - Added SSH key to transport configuration for backward compatibility of old .kitchen.yml ssh_key attributes

I've tested the changes both with SSH and WinRM. Thank you again for your work and of course for your time reviewing this! :)

Have a great day and Regards,
Akos
